### PR TITLE
fix typescript type inference bug for finaliseTwoFactor and revokeTwo…

### DIFF
--- a/src/lib/steam/authenticate.ts
+++ b/src/lib/steam/authenticate.ts
@@ -190,7 +190,7 @@ export async function importTwoFactor(prom: Promise<Electron.OpenDialogReturnVal
 export async function finaliseTwoFactor(activationCode: string): Promise<any>{
     return await new Promise((resolve) => {
         getCommunity().then(community => {
-            community.finalizeTwoFactor(getMainAccount().secrets.shared_secret, activationCode, (err) => {
+            community.finalizeTwoFactor(getMainAccount().secrets.shared_secret, activationCode, (err: Error | null) => {
                 if (err) return resolve({error: err.message});
 
                 // User is using Vapor as their Steam authenticator
@@ -211,7 +211,7 @@ export async function finaliseTwoFactor(activationCode: string): Promise<any>{
 export async function revokeTwoFactor(): Promise<any>{
     return await new Promise((resolve) => {
         getCommunity().then(community => {
-            community.disableTwoFactor(getMainAccount().secrets.revocation_code, (err) => {
+            community.disableTwoFactor(getMainAccount().secrets.revocation_code, (err: Error | null) => {
                 if (err) return resolve({error: err.message});
                 
                 // User is no longer using Vapor as their authenticator - secrets are no longer applicable


### PR DESCRIPTION
change the explicit type for the err parameter in the callback functions of finalizeTwoFactor and revokeTwoFactor as Error | null. This would resolve the TypeScript inference error.  fixed the earlier pull request because of accidentally deleting 
`delete _store.accounts[_store.main].secrets;`