### PR TITLE
Update main.yml to use node-version v14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
       
       - name: Installing all dependencies...
         run: npm ci


### PR DESCRIPTION
When trying to run `npm run build`, the .yml file tries to use node v10.x which is incompatible with some of dependencies like the newer version of tailwindcss